### PR TITLE
Remove registration of push notification services

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -31,10 +31,6 @@
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.INTERNET" />
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-            <permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" android:protectionLevel="signature"/>
-            <uses-permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE"/>
-            <uses-permission android:name="android.permission.WAKE_LOCK" />
-            <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
@@ -43,14 +39,6 @@
                     <action android:name="com.android.vending.INSTALL_REFERRER" />
                 </intent-filter>
             </receiver>
-            <receiver android:name="com.tune.ma.push.service.TunePushReceiver" android:permission="com.google.android.c2dm.permission.SEND">
-                <intent-filter>
-                    <action android:name="com.google.android.c2dm.intent.RECEIVE" />
-                    <category android:name="$PACKAGE_NAME" />
-                    <action android:name="com.google.android.c2dm.intent.REGISTRATION" />
-                </intent-filter>
-            </receiver>
-            <service android:exported="false" android:name="com.tune.ma.push.service.TunePushService" />
         </config-file>
 
         <source-file src="src/android/com/tune/TunePlugin.java"


### PR DESCRIPTION
These prevent other push notification plugins from working when Tune is installed.

Looking at the follow docs:

https://tune.docs.branch.io/sdk/migrating-from-5-x-x-to-6-x-x/#code-platform-android

I am assuming these are no longer required and should have been removed a while ago. Please do let me know if anything should be done differently